### PR TITLE
Python 3 compatibility: `_value_`--> repr(_value_)

### DIFF
--- a/was-full-profile/scripts/deployIoTWHIAuth.py
+++ b/was-full-profile/scripts/deployIoTWHIAuth.py
@@ -23,7 +23,7 @@ try:
   AdminConfig.save()
 except:
   _type_, _value_, _tbck_ = sys.exc_info()
-  error = `_value_`
+  error = repr(_value_)
   print("Error Installing Application")
   print("Error Message = "+error)
   #indicate an error due to an unsuccessful installation


### PR DESCRIPTION
Backticks were removed in Python 3 in favor of __repr()__ that works as expected in both Python 2 and Python 3.