### PR TITLE
Remove the backticks for  Python 3

### DIFF
--- a/was-full-profile/scripts/deployIoTWHIAuth.py
+++ b/was-full-profile/scripts/deployIoTWHIAuth.py
@@ -23,7 +23,7 @@ try:
   AdminConfig.save()
 except:
   _type_, _value_, _tbck_ = sys.exc_info()
-  error = `_value_`
+  error = repr(_value_)
   print("Error Installing Application")
   print("Error Message = "+error)
   #indicate an error due to an unsuccessful installation


### PR DESCRIPTION
__\`\_value\_\`__ is a syntax error in Python but __repr(\_value\_)__ is delivers the same result on both Python 2 and Python 3.

https://portingguide.readthedocs.io/en/latest/syntax.html#backticks